### PR TITLE
Get rid of warnings by making code functional

### DIFF
--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -107,8 +107,10 @@ defmodule ExJsonSchema.Schema do
 
     {newroot, resolver} = 
       if url != "" do
-        {resolve_and_cache_remote_schema(root, url), relative_resolver} 
-        {root, url_with_relative_ref_resolver(url, relative_resolver)}
+        {resolve_and_cache_remote_schema(root, url),
+         url_with_relative_ref_resolver(url, relative_resolver)}
+      else
+        {root, relative_resolver}
       end
 
     assert_reference_valid(resolver, newroot, ref)


### PR DESCRIPTION
I disliked the typical warnings one gets if not using the functional style.

Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/ex_json_schema/schema.ex:190