### PR TITLE
Pass root into resolver

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,10 +1,3 @@
 use Mix.Config
 
-defmodule SchemaResolver do
-  def resolve(_root, url) do
-    schema = HTTPoison.get!(url).body |> Poison.decode!
-    {url, schema}
-  end
-end
-
-config :ex_json_schema, :remote_schema_resolver, &SchemaResolver.resolve/2
+config :ex_json_schema, :remote_schema_resolver, fn url -> HTTPoison.get!(url).body |> Poison.decode! end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,10 @@
 use Mix.Config
 
-config :ex_json_schema, :remote_schema_resolver, fn url -> HTTPoison.get!(url).body |> Poison.decode! end
+defmodule SchemaResolver do
+  def resolve(_root, url) do
+    schema = HTTPoison.get!(url).body |> Poison.decode!
+    {url, schema}
+  end
+end
+
+config :ex_json_schema, :remote_schema_resolver, &SchemaResolver.resolve/2

--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -147,16 +147,16 @@ defmodule ExJsonSchema.Schema do
 
   defp fetch_and_resolve_remote_schema(root, url)
       when url == @current_draft_schema_url or url == @draft4_schema_url do
-    resolve_remote_schema(root, url, Draft4.schema)
+    resolve_remote_schema(root, url, {url, Draft4.schema})
   end
 
   defp fetch_and_resolve_remote_schema(root, url) do
-    resolve_remote_schema(root, url, remote_schema_resolver.(url))
+    resolve_remote_schema(root, url, remote_schema_resolver.(root, url))
   end
 
-  defp resolve_remote_schema(root, url, remote_schema) do
+  defp resolve_remote_schema(root, url, {remote_url, remote_schema}) do
     root = root_with_ref(root, url, remote_schema)
-    resolved_root = resolve_root(%{root | schema: remote_schema, location: url})
+    resolved_root = resolve_root(%{root | schema: remote_schema, location: remote_url})
     root = %{root | refs: resolved_root.refs}
     root_with_ref(root, url, resolved_root.schema)
   end
@@ -166,7 +166,7 @@ defmodule ExJsonSchema.Schema do
   end
 
   defp remote_schema_resolver do
-    Application.get_env(:ex_json_schema, :remote_schema_resolver) || fn _url -> raise UndefinedRemoteSchemaResolverError end
+    Application.get_env(:ex_json_schema, :remote_schema_resolver) || fn _root, _url -> raise UndefinedRemoteSchemaResolverError end
   end
 
   defp assert_reference_valid(path, root, _ref) do


### PR DESCRIPTION
This PR resolves two problems:
1. Ability to resolve schema based on `Root` struct
2. Ability to change resolved path

I need these changes to support related refs in JSON schema files, which are successfully used in Ruby test suite. The following code is my schema resolver:

```elixir
defmodule RemoteSchemaResolver do
  def resolve(root, path) do
    path = resolve_path(root.location, path)
    schema = File.read!(path) |> Poison.decode!
    {path, schema}
  end

  defp resolve_path(:root, path) do
    path
  end
  defp resolve_path(location, path) do
    Regex.replace(~r/(?:.(?!.*\/))+$/, location, "/" <> path)
  end
end
```

As you can see I change path for each nested `Root` so refs inside nested roots are resolved correctly. 

I understand that I introduce a breaking change. Maybe I can avoid it but I haven't figured out yet how to make it
