### PR TITLE
Not to add additionalItems property when not necessary

### DIFF
--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -194,7 +194,7 @@ defmodule ExJsonSchema.Schema do
   end
 
   defp needs_additional_items_attribute?(schema) do
-    Map.has_key?(schema, "items") and not Map.has_key?(schema, "additionalItems")
+    Map.has_key?(schema, "items") and is_list(schema["items"]) and not Map.has_key?(schema, "additionalItems")
   end
 
   defp unescaped_ref_segments(ref) do


### PR DESCRIPTION
Hi,
Thank you for nice library :).

When I create a schema like bellow, `additionalItems` properties is added by `sanitize_additional_items_attribute `.

```json
{"type": "object",  "properties": {"items": {"type": "string"}}}
```

`additionalItems` is meaningless when items is a single schema, so I added the check. 
And this change resolve above problem. :)

See

> Note
> When items is a single schema, the additionalItems keyword is meaningless, and it should not be used.

https://spacetelescope.github.io/understanding-json-schema/reference/array.html

Thanks,