### PR TITLE
Return unkown for datatypes not explicitly checked

### DIFF
--- a/lib/ex_json_schema/validator/type.ex
+++ b/lib/ex_json_schema/validator/type.ex
@@ -34,6 +34,7 @@ defmodule ExJsonSchema.Validator.Type do
       is_number(data) -> "number"
       is_list(data) -> "array"
       is_map(data) -> "object"
+      true -> "unknown"
     end
   end
 

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -128,9 +128,10 @@ defmodule ExJsonSchema.ValidatorTest do
   test "validation errors for invalid items" do
     assert_validation_errors(
       %{"items" => %{"type" => "string"}},
-      ["foo", "bar", 1, %{}], [
+      ["foo", "bar", 1, %{}, {"foo", "bar"}], [
         {"Type mismatch. Expected String but got Integer.", "#/2"},
-        {"Type mismatch. Expected String but got Object.", "#/3"}])
+        {"Type mismatch. Expected String but got Object.", "#/3"},
+        {"Type mismatch. Expected String but got Unknown.", "#/4"}])
   end
 
   test "validation errors for an invalid item with a list of item schemata and an invalid additional item" do


### PR DESCRIPTION
This deals with #20. There are cases where a module will have unsupported data types passed to it and this allows for a more graceful handling without requiring changes to any upstream modules.