### PR TITLE
Replace Map.size with Kernel.map_size, as per deprecation warning

### DIFF
--- a/lib/ex_json_schema/validator.ex
+++ b/lib/ex_json_schema/validator.ex
@@ -179,14 +179,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"minProperties", min_properties}, data) when is_map(data) do
-    case Map.size(data) >= min_properties do
+    case map_size(data) >= min_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MinProperties{expected: min_properties, actual: Map.size(data)},
+            error: %Error.MinProperties{expected: min_properties, actual: map_size(data)},
             path: ""
           }
         ]
@@ -194,14 +194,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"maxProperties", max_properties}, data) when is_map(data) do
-    case Map.size(data) <= max_properties do
+    case map_size(data) <= max_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MaxProperties{expected: max_properties, actual: Map.size(data)},
+            error: %Error.MaxProperties{expected: max_properties, actual: map_size(data)},
             path: ""
           }
         ]


### PR DESCRIPTION
When compiling a project that uses `ex_json_schema`, I saw the following warning:

```
warning: Map.size/1 is deprecated. Use Kernel.map_size/1 instead
Found at 4 locations:
  lib/ex_json_schema/validator.ex:99
  lib/ex_json_schema/validator.ex:101
  lib/ex_json_schema/validator.ex:106
  lib/ex_json_schema/validator.ex:108
```

And so made this small change accordingly.