### PR TITLE
Fix warnings appearing on Elixir 1.9

### DIFF
--- a/lib/ex_json_schema/validator.ex
+++ b/lib/ex_json_schema/validator.ex
@@ -179,14 +179,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"minProperties", min_properties}, data) when is_map(data) do
-    case Map.size(data) >= min_properties do
+    case map_size(data) >= min_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MinProperties{expected: min_properties, actual: Map.size(data)},
+            error: %Error.MinProperties{expected: min_properties, actual: map_size(data)},
             path: ""
           }
         ]
@@ -194,14 +194,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"maxProperties", max_properties}, data) when is_map(data) do
-    case Map.size(data) <= max_properties do
+    case map_size(data) <= max_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MaxProperties{expected: max_properties, actual: Map.size(data)},
+            error: %Error.MaxProperties{expected: max_properties, actual: map_size(data)},
             path: ""
           }
         ]

--- a/lib/ex_json_schema/validator/properties.ex
+++ b/lib/ex_json_schema/validator/properties.ex
@@ -70,7 +70,7 @@ defmodule ExJsonSchema.Validator.Properties do
 
   defp unvalidated_properties(properties, validated_properties) do
     unvalidated = MapSet.difference(keys_as_set(properties), keys_as_set(validated_properties))
-    Map.take(properties, unvalidated)
+    Map.take(properties, Enum.to_list(unvalidated))
   end
 
   defp keys_as_set(properties) do


### PR DESCRIPTION
The `to_list` one is particularly annoying, as it appears on every call in runtime, making test output unreadable.