### PR TITLE
Deprecation warnings fixed

### DIFF
--- a/lib/ex_json_schema/validator.ex
+++ b/lib/ex_json_schema/validator.ex
@@ -179,14 +179,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"minProperties", min_properties}, data) when is_map(data) do
-    case Map.size(data) >= min_properties do
+    case map_size(data) >= min_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MinProperties{expected: min_properties, actual: Map.size(data)},
+            error: %Error.MinProperties{expected: min_properties, actual: map_size(data)},
             path: ""
           }
         ]
@@ -194,14 +194,14 @@ defmodule ExJsonSchema.Validator do
   end
 
   defp validate_aspect(_, _, {"maxProperties", max_properties}, data) when is_map(data) do
-    case Map.size(data) <= max_properties do
+    case map_size(data) <= max_properties do
       true ->
         []
 
       false ->
         [
           %Error{
-            error: %Error.MaxProperties{expected: max_properties, actual: Map.size(data)},
+            error: %Error.MaxProperties{expected: max_properties, actual: map_size(data)},
             path: ""
           }
         ]

--- a/lib/ex_json_schema/validator/properties.ex
+++ b/lib/ex_json_schema/validator/properties.ex
@@ -69,8 +69,12 @@ defmodule ExJsonSchema.Validator.Properties do
   end
 
   defp unvalidated_properties(properties, validated_properties) do
-    unvalidated = MapSet.difference(keys_as_set(properties), keys_as_set(validated_properties))
-    Map.take(properties, unvalidated)
+    keys =
+      properties
+      |> keys_as_set()
+      |> MapSet.difference(keys_as_set(validated_properties))
+      |> Enum.to_list()
+    Map.take(properties, keys)
   end
 
   defp keys_as_set(properties) do


### PR DESCRIPTION
I'm using elixir 1.9.1 and I have a lot of deprecation warnings in my log:

```text
warning: Map.take/2 with an Enumerable of keys that is not a list is deprecated.  Use a list of keys instead.
  (elixir) lib/map.ex:395: Map.take/2
  (ex_json_schema) lib/ex_json_schema/validator/properties.ex:16: ExJsonSchema.Validator.Properties.validate/3
  (elixir) lib/enum.ex:1053: anonymous fn/3 in Enum.flat_map/2
  (stdlib) maps.erl:232: :maps.fold_1/3
  (elixir) lib/enum.ex:1964: Enum.flat_map/2
  (ex_json_schema) lib/ex_json_schema/validator.ex:62: ExJsonSchema.Validator.validation_errors/4
  (ex_json_schema) lib/ex_json_schema/validator.ex:34: ExJsonSchema.Validator.validate_fragment/4
  (ex_json_schema) lib/ex_json_schema/schema.ex:78: ExJsonSchema.Schema.assert_valid_schema/1
  (ex_json_schema) lib/ex_json_schema/schema.ex:67: ExJsonSchema.Schema.resolve_root/1
```

and

```text
warning: Map.size/1 is deprecated. Use Kernel.map_size/1 instead
Found at 4 locations:
  lib/ex_json_schema/validator.ex:182
  lib/ex_json_schema/validator.ex:189
  lib/ex_json_schema/validator.ex:197
  lib/ex_json_schema/validator.ex:204
```

I fixed the warnings, but `mix test` crashes in general at my machine with and without my changes. 

I did:
`git clone ...`
`mix dips.get`
`mix test`

I'm using MacOS 10.14.5 with 
```text
Erlang/OTP 22 [erts-10.4.4] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe] [dtrace]

Interactive Elixir (1.9.1) - press Ctrl+C to exit (type h() ENTER for help)
```

Please check my changes and the test issue.

Regards