### PR TITLE
Add const word validation

### DIFF
--- a/lib/ex_json_schema/validator.ex
+++ b/lib/ex_json_schema/validator.ex
@@ -251,6 +251,13 @@ defmodule ExJsonSchema.Validator do
     end
   end
 
+  defp validate_aspect(_, _, {"const", const}, data) do
+    case const == data do
+      true -> []
+      false -> [%Error{error: %Error.Const{expected: const, actual: data}, path: ""}]
+    end
+  end
+
   defp validate_aspect(_, schema, {"minimum", minimum}, data) when is_number(data) do
     exclusive? = schema["exclusiveMinimum"] || false
     fun = if exclusive?, do: &Kernel.>/2, else: &Kernel.>=/2

--- a/lib/ex_json_schema/validator/error.ex
+++ b/lib/ex_json_schema/validator/error.ex
@@ -65,6 +65,10 @@ defmodule ExJsonSchema.Validator.Error do
     defstruct([])
   end
 
+  defmodule Const do
+    defstruct([:expected, :actual])
+  end
+
   defmodule Minimum do
     defstruct([:expected, :exclusive?])
   end

--- a/lib/ex_json_schema/validator/error/string_formatter.ex
+++ b/lib/ex_json_schema/validator/error/string_formatter.ex
@@ -166,4 +166,10 @@ defmodule ExJsonSchema.Validator.Error.StringFormatter do
     defp format_name("ipv6"), do: "IPv6 address"
     defp format_name(expected), do: expected
   end
+
+  defimpl String.Chars, for: Error.Const do
+    def to_string(%Error.Const{expected: expected, actual: actual}) do
+      "Expected string to be #{inspect(expected)} but was #{inspect(actual)}"
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExJsonSchema.Mixfile do
   def project do
     [
       app: :ex_json_schema,
-      version: "0.7.3",
+      version: "0.7.4",
       elixir: "~> 1.3",
       description:
         "A JSON Schema validator with full support for the draft 4 specification and zero dependencies.",

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -390,6 +390,17 @@ defmodule ExJsonSchema.ValidatorTest do
     )
   end
 
+  test "validation errors for value not equal to const" do
+    value = %{"bar" => 1}
+
+    assert_validation_errors(
+      %{"const" => "foo"},
+      value,
+      [{~s/Expected string to be "foo" but was #{inspect(value)}/, "#"}],
+      [%Error{error: %Error.Const{actual: value, expected: "foo"}, path: "#"}]
+    )
+  end
+
   test "validation errors for minimum values" do
     assert_validation_errors(
       %{


### PR DESCRIPTION
This adds support for the const word from draft 6 of the schema. Addresses #35 

I am not sure how you want to go forward with supporting different versions of the JSON schema drafts, possibly passing in runtime the version of the draft and matching on it in the validators for example?

Anyway feel free to close this PR if this isn't the direction you envision, and do ping me if you need help with this work!