### PR TITLE
expands dialyzer definition, it was incomplete if you resolve something that is an edge node.

### DIFF
--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -21,9 +21,7 @@ defmodule ExJsonSchema.Schema do
   alias ExJsonSchema.Validator
 
   @type ref_path :: [:root | String.t()]
-  @type resolved :: %{
-          String.t() => ExJsonSchema.data() | (Root.t() -> {Root.t(), resolved}) | ref_path
-        }
+  @type resolved :: ExJsonSchema.data() | %{String.t() =>  (Root.t() -> {Root.t(), resolved}) | ref_path}
   @type invalid_reference_error :: {:error, :invalid_reference}
 
   @current_draft_schema_url "http://json-schema.org/schema"


### PR DESCRIPTION
for example  I am using the libary like so
```elixir
ExJsonSchema.Schema.get_fragment(spec, [
             :root,
             "paths",
             path,
             method,
             "requestBody",
             "required"
           ])
```
which returns
```elixir
{:ok, true}
````
which violates spec. this pr fixes the spec definition.