### PR TITLE
fix date-time format validation

### DIFF
--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -4,8 +4,6 @@ defmodule ExJsonSchema.Validator.Format do
   alias ExJsonSchema.Schema.Root
 
   @formats %{
-    "date-time" =>
-      ~r/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[tT](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?([zZ]|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/,
     "email" =>
       ~r<^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,}$>i,
     "hostname" => ~r/^((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}$/i,
@@ -22,8 +20,15 @@ defmodule ExJsonSchema.Validator.Format do
 
   def validate(%Root{}, _, _), do: []
 
+  defp do_validate(%Root{}, format = "date-time", data) do
+    case DateTime.from_iso8601(data) do
+      {:ok, _, _} -> []
+      {:error, _} -> [%Error{error: %Error.Format{expected: format}, path: ""}]
+    end
+  end
+
   defp do_validate(%Root{}, format, data)
-       when format in ["date-time", "email", "hostname", "ipv4", "ipv6"] do
+       when format in ["email", "hostname", "ipv4", "ipv6"] do
     case Regex.match?(@formats[format], data) do
       true -> []
       false -> [%Error{error: %Error.Format{expected: format}, path: ""}]

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -21,7 +21,7 @@ defmodule ExJsonSchema.Validator.Format do
   def validate(%Root{}, _, _), do: []
 
   defp do_validate(%Root{}, format = "date-time", data) do
-    case DateTime.from_iso8601(data) do
+    case DateTime.from_iso8601(String.upcase(data)) do
       {:ok, _, _} -> []
       {:error, _} -> [%Error{error: %Error.Format{expected: format}, path: ""}]
     end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExJsonSchema.Mixfile do
     [
       app: :ex_json_schema,
       version: "0.7.4",
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       description:
         "A JSON Schema validator with full support for the draft 4 specification and zero dependencies.",
       deps: deps(),

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -484,6 +484,13 @@ defmodule ExJsonSchema.ValidatorTest do
       [{"Expected to be a valid ISO 8601 date-time.", "#"}],
       [%Error{error: %Error.Format{expected: "date-time"}, path: "#"}]
     )
+
+    assert_validation_errors(
+      %{"format" => "date-time"},
+      "20200-03-22T06:28:23Z",
+      [{"Expected to be a valid ISO 8601 date-time.", "#"}],
+      [%Error{error: %Error.Format{expected: "date-time"}, path: "#"}]
+    )
   end
 
   test "validation errors for email format" do


### PR DESCRIPTION
The current regex to validate date-time doesn't capture all the
invalid dates. Also the spec mandates proper day validation, that is,
february can't have 29 on non leap year etc which can't be validated
via regex.

This commit uses the DateTime module from standard library to do the
validation. Given that the function is available since 1.4, support
for 1.3 is dropped.