### PR TITLE
Use `Date`/`DateTime` to parse `date`/`date-time` types

### DIFF
--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -14,9 +14,6 @@ defmodule ExJsonSchema.Validator.Format do
   @behaviour ExJsonSchema.Validator
 
   @formats %{
-    "date" => ~r/^(\d\d\d\d)-(\d\d)-(\d\d)$/,
-    "date-time" =>
-      ~r/^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])[tT](2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?([zZ]|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$/,
     "email" =>
       ~r<^[\w!#$%&'*+/=?`{|}~^-]+(?:\.[\w!#$%&'*+/=?`{|}~^-]+)*@(?:[A-Z0-9-]+\.)+[a-z]{2,}$>i,
     "hostname" =>
@@ -57,10 +54,25 @@ defmodule ExJsonSchema.Validator.Format do
     []
   end
 
+  defp do_validate(_, "date" = format, data) do
+    case Date.from_iso8601(data) do
+      {:ok, %Date{}} -> []
+      _ -> [%Error{error: %Error.Format{expected: format}}]
+    end
+  end
+
+  defp do_validate(_, "date-time" = format, data) do
+    data
+    |> String.upcase()
+    |> DateTime.from_iso8601()
+    |> case do
+      {:ok, %DateTime{}, _} -> []
+      _ -> [%Error{error: %Error.Format{expected: format}}]
+    end
+  end
+
   defp do_validate(_, format, data)
        when format in [
-              "date",
-              "date-time",
               "email",
               "idn-email",
               "idn-hostname",


### PR DESCRIPTION
Hi there, thank you for this library :raised_hands:

This is a small PR to use the native `Date` and `DateTime` modules (available since Elixir 1.6) to validate the `date` and `date-time` field types.

I've detected this problem since it was allowing a `2020-15-15` date, since the `date` was being validated against a `\d{4}-\d{2}-\d{2}` regex.

I've ran the `draft-07` test suite, everything working as expected:

```
❯ MIX_ENV=test mix test test/json_schema_draft7_test_suite_test.exs:6
Excluding tags: [:test]
Including tags: [line: "6"]

**************........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Finished in 4.3 seconds (4.3s async, 0.00s sync)
806 tests, 0 failures, 14 skipped

Randomized with seed 33195
```