### PR TITLE
Allow naive date-time to be a valid date-time format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ elixir:
   - 1.7
   - 1.8
   - 1.9
+  - 1.12
 otp_release:
   - 19.3
   - 20.3
   - 21.0
   - 22.0
+  - 24.0
 matrix:
   exclude:
     - elixir: 1.6

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -61,12 +61,23 @@ defmodule ExJsonSchema.Validator.Format do
     end
   end
 
-  defp do_validate(_, "date-time" = format, data) do
+  defp do_validate(root, "date-time" = format, data) do
     data
     |> String.upcase()
     |> DateTime.from_iso8601()
     |> case do
       {:ok, %DateTime{}, _} -> []
+      {:error, :missing_offset} -> do_validate(root, "naive-datetime", data)
+      _ -> [%Error{error: %Error.Format{expected: format}}]
+    end
+  end
+
+  defp do_validate(_, "naive-date-time" = format, data) do
+    data
+    |> String.upcase()
+    |> NaiveDateTime.from_iso8601()
+    |> case do
+      {:ok, %NaiveDateTime{}, _} -> []
       _ -> [%Error{error: %Error.Format{expected: format}}]
     end
   end

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -669,7 +669,6 @@ defmodule ExJsonSchema.ValidatorTest do
 
   test "format validation succeeds for a naive datetime" do
     assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12")
-    )
   end
 
   test "validation errors for date-time format" do

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -667,10 +667,15 @@ defmodule ExJsonSchema.ValidatorTest do
     assert :ok == validate(%{"format" => "date-time"}, false)
   end
 
+  test "format validation succeeds for a naive datetime" do
+    assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12")
+    )
+  end
+
   test "validation errors for date-time format" do
     assert_validation_errors(
       %{"format" => "date-time"},
-      "2012-12-12 12:12:12",
+      "2012-12-12 12:12:12-1.5",
       [{"Expected to be a valid ISO 8601 date-time.", "#"}],
       [%Error{error: %Error.Format{expected: "date-time"}, path: "#"}]
     )


### PR DESCRIPTION
Ever since #64 was merged, when using `NaiveDateTime` for dates, JSON validations started failing.
This commit allows for `NaiveDateTime` strings to be accepted as `date-time` ex_json schema formats.