### PR TITLE
Use NaiveDatetime as parsing module for date-time format

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the project to your Mix dependencies in `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:ex_json_schema, "~> 0.9.0"}
+    {:ex_json_schema, "~> 0.9.1"}
   ]
 end
 ```

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -64,9 +64,9 @@ defmodule ExJsonSchema.Validator.Format do
   defp do_validate(_, "date-time" = format, data) do
     data
     |> String.upcase()
-    |> DateTime.from_iso8601()
+    |> NaiveDateTime.from_iso8601()
     |> case do
-      {:ok, %DateTime{}, _} -> []
+      {:ok, %NaiveDateTime{}, _} -> []
       _ -> [%Error{error: %Error.Format{expected: format}}]
     end
   end

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -66,7 +66,7 @@ defmodule ExJsonSchema.Validator.Format do
     |> String.upcase()
     |> NaiveDateTime.from_iso8601()
     |> case do
-      {:ok, %NaiveDateTime{}, _} -> []
+      {:ok, %NaiveDateTime{}} -> []
       _ -> [%Error{error: %Error.Format{expected: format}}]
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule ExJsonSchema.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/jonasschmidt/ex_json_schema"
-  @version "0.9.0"
+  @version "0.9.1"
 
   def project do
     [

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -668,7 +668,7 @@ defmodule ExJsonSchema.ValidatorTest do
   end
 
   test "format validation succeeds for datetime with tz offset" do
-    assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12Z")
+    assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12")
   end
 
   test "validation errors for date-time format" do

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -667,10 +667,14 @@ defmodule ExJsonSchema.ValidatorTest do
     assert :ok == validate(%{"format" => "date-time"}, false)
   end
 
+  test "format validation succeeds for datetime with tz offset" do
+    assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12Z")
+  end
+
   test "validation errors for date-time format" do
     assert_validation_errors(
       %{"format" => "date-time"},
-      "2012-12-12 12:12:12",
+      "2012-12-12 12:12:12-1.5",
       [{"Expected to be a valid ISO 8601 date-time.", "#"}],
       [%Error{error: %Error.Format{expected: "date-time"}, path: "#"}]
     )

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -667,7 +667,7 @@ defmodule ExJsonSchema.ValidatorTest do
     assert :ok == validate(%{"format" => "date-time"}, false)
   end
 
-  test "format validation succeeds for datetime with tz offset" do
+  test "format validation succeeds for datetime without tz offset" do
     assert :ok == validate(%{"format" => "date-time"}, "2012-12-12 12:12:12")
   end
 


### PR DESCRIPTION
Ever since #64 was merged, when using NaiveDateTime for dates, JSON validations started failing.
This commit allows for NaiveDateTime strings to be accepted as date-time ex_json schema formats.