### PR TITLE
Add config option for detailed message for nested errors

### DIFF
--- a/lib/ex_json_schema/validator/error/string_formatter.ex
+++ b/lib/ex_json_schema/validator/error/string_formatter.ex
@@ -207,6 +207,7 @@ defmodule ExJsonSchema.Validator.Error.StringFormatter do
     The following errors were found:
       #{error_messages}
     """
+    |> String.trim()
   end
 
   def detailed?() do


### PR DESCRIPTION
This PR adds ability to set `detailed_errors` feature flag in config. 

Setting this enables detailed error output for errors that can contain other errors inside, e.g. `AllOf`, `AnyOf`

Example detailed message for `AllOf` with nested `AnyOf`  looks like this:
```
Expected all of the schemata to match, but the schemata at the following indexes did not: 1.

The following errors were found:
  1: Expected any of the schemata to match but none did.
  
  The following errors were found:
    0: Expected data to be "1".
    1: Expected data to be "2".
    2: Expected data to be "3".
    3: Expected data to be "4".
    4: Expected data to be "5".
    5: Expected data to be "6".
```