### PR TITLE
Introduces checks for nullable property in schema

### DIFF
--- a/lib/ex_json_schema/validator/type.ex
+++ b/lib/ex_json_schema/validator/type.ex
@@ -14,6 +14,11 @@ defmodule ExJsonSchema.Validator.Type do
   @behaviour ExJsonSchema.Validator
 
   @impl ExJsonSchema.Validator
+
+  def validate(%{version: version}, %{"nullable" => nullable}, {"type", type}, data, _) do
+    do_validate(version, type, data, nullable: nullable)
+  end
+
   def validate(%{version: version}, _, {"type", type}, data, _) do
     do_validate(version, type, data)
   end
@@ -27,11 +32,11 @@ defmodule ExJsonSchema.Validator.Type do
           type :: ExJsonSchema.data(),
           data :: ExJsonSchema.data()
         ) :: Validator.errors()
-  defp do_validate(version, type, data) do
-    if valid?(version, type, data) do
-      []
-    else
-      [%Error{error: %Error.Type{expected: List.wrap(type), actual: data_type(data)}}]
+  defp do_validate(version, type, data, [nullable: nullable] \\ [nullable: false]) do
+    cond do
+      nullable && is_nil(data) -> []
+      valid?(version, type, data) -> []
+      true -> [%Error{error: %Error.Type{expected: List.wrap(type), actual: data_type(data)}}]
     end
   end
 

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -764,6 +764,10 @@ defmodule ExJsonSchema.ValidatorTest do
              validate(%{"type" => "string"}, 666, error_formatter: Error.StringFormatter)
   end
 
+  test "xx" do
+    assert :ok = validate(%{"type" => "string", "nullable" => true}, nil, error_formatter: Error.StringFormatter)
+  end
+
   test "using the string formatter by default" do
     assert {:error, [{"Type mismatch. Expected String but got Integer.", "#"}]} = validate(%{"type" => "string"}, 666)
   end

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -764,8 +764,13 @@ defmodule ExJsonSchema.ValidatorTest do
              validate(%{"type" => "string"}, 666, error_formatter: Error.StringFormatter)
   end
 
-  test "xx" do
+  test "allows attibute to have value nil if nullable is allowed" do
     assert :ok = validate(%{"type" => "string", "nullable" => true}, nil, error_formatter: Error.StringFormatter)
+  end
+
+  test "does not allowe nil values" do
+    assert {:error, [{"Type mismatch. Expected String but got Null.", "#"}]} =
+             validate(%{"type" => "string", "nullable" => false}, nil, error_formatter: Error.StringFormatter)
   end
 
   test "using the string formatter by default" do


### PR DESCRIPTION
This is one possibility on treating `nullable` types. 
This solution does not follow validator logic, and the check is done from `Validator.Type`, this allows that the previous logic still works, and values are going to be checked for `nil` only if `nullable` is set. If `nullable` is not set, the previous logic of `do_validate` where `nil` is not treated as an allowed value will get applied. 