### PR TITLE
Support anonymous functions as custom validator function

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ ExJsonSchema.Schema.resolve(%{"format" => "custom"}, custom_format_validator: {M
 
 The configured function is called with the arguments `(format, data)` and is expected to return `true`, `false` or a `{:error, %Error.Format{expected: "something"}}` tuple, depending whether the data is valid for the given format. For compatibility with JSON schema, it is expected to return `true` when the format is unknown by your callback function.
 
+The custom function can also be an anonymous function:
+
+```elixir
+ExJsonSchema.Schema.resolve(%{"format" => "custom"}, custom_format_validator: fn format, data -> true end)
+```
+
 [format-spec]: https://json-schema.org/understanding-json-schema/reference/string.html#format
 
 ## License
@@ -180,5 +186,5 @@ Released under the [MIT license](https://github.com/jonasschmidt/ex_json_schema/
 
 ## TODO
 
-* Add some source code documentation
-* Enable providing JSON for known schemata at resolve time
+- Add some source code documentation
+- Enable providing JSON for known schemata at resolve time

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The custom function can also be an anonymous function:
 ExJsonSchema.Schema.resolve(%{"format" => "custom"}, custom_format_validator: fn format, data -> true end)
 ```
 
+> Note that the anonymous function version of the custom validator is only available in the option to Schema.resolve/2 and not as Application config, as using anonymous functions as configuration is not allowed.
+
 [format-spec]: https://json-schema.org/understanding-json-schema/reference/string.html#format
 
 ## License

--- a/lib/ex_json_schema/schema/root.ex
+++ b/lib/ex_json_schema/schema/root.ex
@@ -12,6 +12,6 @@ defmodule ExJsonSchema.Schema.Root do
           location: :root | String.t(),
           definitions: %{String.t() => ExJsonSchema.Schema.resolved()},
           version: non_neg_integer | nil,
-          custom_format_validator: {module(), atom()} | nil
+          custom_format_validator: {module(), atom()} | (String.t(), any() -> boolean | {:error, any()}) | nil
         }
 end

--- a/lib/ex_json_schema/validator/format.ex
+++ b/lib/ex_json_schema/validator/format.ex
@@ -99,7 +99,6 @@ defmodule ExJsonSchema.Validator.Format do
   defp do_validate(%Root{custom_format_validator: nil}, format, data) do
     case Application.fetch_env(:ex_json_schema, :custom_format_validator) do
       :error -> []
-      {:ok, validator} when is_function(validator, 2) -> validate_with_custom_validator(validator, format, data)
       {:ok, validator = {_mod, _fun}} -> validate_with_custom_validator(validator, format, data)
     end
   end

--- a/test/ex_json_schema/validator_test.exs
+++ b/test/ex_json_schema/validator_test.exs
@@ -780,6 +780,31 @@ defmodule ExJsonSchema.ValidatorTest do
     )
   end
 
+  test "configuring an anonymous function as custom format validator" do
+    anonymous_validation_fn = fn "myformat", data ->
+      data == "mydata"
+    end
+
+    schema =
+      Schema.resolve(
+        %{
+          "properties" => %{
+            "error" => %{"format" => "myformat"}
+          }
+        },
+        custom_format_validator: anonymous_validation_fn
+      )
+
+    assert :ok = validate(schema, %{"error" => "mydata"})
+
+    assert_validation_errors(
+      schema,
+      %{"error" => ""},
+      [{"Expected to be a valid myformat.", "#/error"}],
+      [%Error{error: %Error.Format{expected: "myformat"}, path: "#/error"}]
+    )
+  end
+
   test "passing the formatter as an option" do
     assert :ok = validate(%{"type" => "string"}, "foo", error_formatter: Error.StringFormatter)
 


### PR DESCRIPTION
Using an function closure allows one to use custom, context-specific data inside the validation function.