### PR TITLE
Remove elixir v1.19 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             otp: 24.3.4.17
           - elixir: 1.18.1
             otp: 27.2
+          - elixir: 1.19.0
+            otp: 27.2
     env:
       MIX_ENV: test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
             otp: 24.3.4.17
           - elixir: 1.18.1
             otp: 27.2
-          - elixir: 1.19.0
-            otp: 27.2
+          - elixir: 1.19.4
+            otp: 28.3
     env:
       MIX_ENV: test
     steps:

--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -121,10 +121,10 @@ defmodule ExJsonSchema.Schema do
           message: "schema did not pass validation against its meta-schema: #{inspect(errors)}"
     end
 
-    root = %{root | version: schema_version}
-    {root, schema} = resolve_with_root(root, root_schema, scope)
+    root = %Root{root | version: schema_version}
+    {%Root{} = root, schema} = resolve_with_root(root, root_schema, scope)
 
-    %{root | schema: schema}
+    %Root{root | schema: schema}
     |> resolve_refs(schema)
   end
 

--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -121,10 +121,10 @@ defmodule ExJsonSchema.Schema do
           message: "schema did not pass validation against its meta-schema: #{inspect(errors)}"
     end
 
-    root = %Root{root | version: schema_version}
+    root = %{root | version: schema_version}
     {root, schema} = resolve_with_root(root, root_schema, scope)
 
-    %Root{root | schema: schema}
+    %{root | schema: schema}
     |> resolve_refs(schema)
   end
 
@@ -366,5 +366,5 @@ defmodule ExJsonSchema.Schema do
     do: raise(InvalidReferenceError, message: "invalid reference #{ref}")
 
   def raise_invalid_reference_error(ref),
-    do: ref |> to_string() |> raise_invalid_reference_error
+    do: ref |> to_string() |> raise_invalid_reference_error()
 end

--- a/lib/ex_json_schema/schema/ref.ex
+++ b/lib/ex_json_schema/schema/ref.ex
@@ -29,7 +29,7 @@ defmodule ExJsonSchema.Schema.Ref do
     %__MODULE__{location: location} |> parse_fragment(fragment)
   end
 
-  defp parse_fragment(ref, fragment) when fragment in [nil, ""], do: %{ref | fragment: []}
+  defp parse_fragment(%__MODULE__{} = ref, fragment) when fragment in [nil, ""], do: %__MODULE__{ref | fragment: []}
 
   defp parse_fragment(ref, "/" <> _ = pointer) do
     keys = unescaped_ref_segments(pointer)

--- a/lib/ex_json_schema/schema/ref.ex
+++ b/lib/ex_json_schema/schema/ref.ex
@@ -45,7 +45,7 @@ defmodule ExJsonSchema.Schema.Ref do
     %{ref | fragment: pointer, fragment_pointer?: true}
   end
 
-  defp parse_fragment(ref, id), do: %{ref | fragment: [id]}
+  defp parse_fragment(%__MODULE__{} = ref, id), do: %__MODULE__{ref | fragment: [id]}
 
   defp unescaped_ref_segments(ref) do
     ref

--- a/lib/ex_json_schema/schema/ref.ex
+++ b/lib/ex_json_schema/schema/ref.ex
@@ -31,7 +31,7 @@ defmodule ExJsonSchema.Schema.Ref do
 
   defp parse_fragment(%__MODULE__{} = ref, fragment) when fragment in [nil, ""], do: %__MODULE__{ref | fragment: []}
 
-  defp parse_fragment(ref, "/" <> _ = pointer) do
+  defp parse_fragment(%__MODULE__{} = ref, "/" <> _ = pointer) do
     keys = unescaped_ref_segments(pointer)
 
     pointer =
@@ -42,7 +42,7 @@ defmodule ExJsonSchema.Schema.Ref do
         end
       end)
 
-    %{ref | fragment: pointer, fragment_pointer?: true}
+    %__MODULE__{ref | fragment: pointer, fragment_pointer?: true}
   end
 
   defp parse_fragment(%__MODULE__{} = ref, id), do: %__MODULE__{ref | fragment: [id]}

--- a/lib/ex_json_schema/schema/ref.ex
+++ b/lib/ex_json_schema/schema/ref.ex
@@ -29,7 +29,7 @@ defmodule ExJsonSchema.Schema.Ref do
     %__MODULE__{location: location} |> parse_fragment(fragment)
   end
 
-  defp parse_fragment(ref, fragment) when fragment in [nil, ""], do: %__MODULE__{ref | fragment: []}
+  defp parse_fragment(ref, fragment) when fragment in [nil, ""], do: %{ref | fragment: []}
 
   defp parse_fragment(ref, "/" <> _ = pointer) do
     keys = unescaped_ref_segments(pointer)
@@ -42,10 +42,10 @@ defmodule ExJsonSchema.Schema.Ref do
         end
       end)
 
-    %__MODULE__{ref | fragment: pointer, fragment_pointer?: true}
+    %{ref | fragment: pointer, fragment_pointer?: true}
   end
 
-  defp parse_fragment(ref, id), do: %__MODULE__{ref | fragment: [id]}
+  defp parse_fragment(ref, id), do: %{ref | fragment: [id]}
 
   defp unescaped_ref_segments(ref) do
     ref

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,6 @@ defmodule ExJsonSchema.Mixfile do
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test, dialyzer: :test],
       dialyzer: [
         plt_add_apps: [:ex_unit]
       ]
@@ -27,6 +26,10 @@ defmodule ExJsonSchema.Mixfile do
 
   def application do
     [extra_applications: []]
+  end
+
+  def cli do
+    [preferred_envs: [coveralls: :test, dialyzer: :test]]
   end
 
   defp deps do


### PR DESCRIPTION
**After**

```sh
$ mix compile --force
Compiling 40 files (.ex)
Generated ex_json_schema app
```

**Before**

```sh
$ mix compile --force
warning: setting :preferred_cli_env in your mix.exs "def project" is deprecated, set it inside "def cli" instead:

    def cli do
      [preferred_envs: [coveralls: :test, dialyzer: :test]]
    end

  (mix 1.19.4) lib/mix/cli.ex:187: Mix.CLI.preferred_cli_env/3
  (mix 1.19.4) lib/mix/cli.ex:170: Mix.CLI.maybe_change_env_and_target/2
  (mix 1.19.4) lib/mix/cli.ex:59: Mix.CLI.proceed/2
  /Users/santiago/.asdf/installs/elixir/1.19.4-otp-28/bin/mix:7: (file)
  (elixir 1.19.4) src/elixir_compiler.erl:81: :elixir_compiler.dispatch/4
  (elixir 1.19.4) src/elixir_compiler.erl:56: :elixir_compiler.compile/4

Compiling 2 files (.ex)
    warning: a struct for ExJsonSchema.Schema.Ref is expected on struct update:

        %ExJsonSchema.Schema.Ref{ref | fragment: []}

    but got type:

        dynamic()

    where "ref" was given the type:

        # type: dynamic()
        # from: lib/ex_json_schema/schema/ref.ex:32:23
        ref

    when defining the variable "ref", you must also pattern match on "%ExJsonSchema.Schema.Ref{}".

    hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

        user = some_function()
        %User{user | name: "John Doe"}

    it is enough to write:

        %User{} = user = some_function()
        %{user | name: "John Doe"}

    typing violation found at:
    │
 32 │   defp parse_fragment(ref, fragment) when fragment in [nil, ""], do: %__MODULE__{ref | fragment: []}
    │                                                                      ~
    │
    └─ lib/ex_json_schema/schema/ref.ex:32:70: ExJsonSchema.Schema.Ref.parse_fragment/2

    warning: a struct for ExJsonSchema.Schema.Ref is expected on struct update:

        %ExJsonSchema.Schema.Ref{ref | fragment: pointer, fragment_pointer?: true}

    but got type:

        dynamic()

    where "ref" was given the type:

        # type: dynamic()
        # from: lib/ex_json_schema/schema/ref.ex:34:23
        ref

    when defining the variable "ref", you must also pattern match on "%ExJsonSchema.Schema.Ref{}".

    hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

        user = some_function()
        %User{user | name: "John Doe"}

    it is enough to write:

        %User{} = user = some_function()
        %{user | name: "John Doe"}

    typing violation found at:
    │
 45 │     %__MODULE__{ref | fragment: pointer, fragment_pointer?: true}
    │     ~
    │
    └─ lib/ex_json_schema/schema/ref.ex:45:5: ExJsonSchema.Schema.Ref.parse_fragment/2

    warning: a struct for ExJsonSchema.Schema.Ref is expected on struct update:

        %ExJsonSchema.Schema.Ref{ref | fragment: [id]}

    but got type:

        dynamic()

    where "ref" was given the type:

        # type: dynamic()
        # from: lib/ex_json_schema/schema/ref.ex:48:23
        ref

    when defining the variable "ref", you must also pattern match on "%ExJsonSchema.Schema.Ref{}".

    hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

        user = some_function()
        %User{user | name: "John Doe"}

    it is enough to write:

        %User{} = user = some_function()
        %{user | name: "John Doe"}

    typing violation found at:
    │
 48 │   defp parse_fragment(ref, id), do: %__MODULE__{ref | fragment: [id]}
    │                                     ~
    │
    └─ lib/ex_json_schema/schema/ref.ex:48:37: ExJsonSchema.Schema.Ref.parse_fragment/2

     warning: a struct for ExJsonSchema.Schema.Root is expected on struct update:

         %ExJsonSchema.Schema.Root{root | schema: schema}

     but got type:

         dynamic()

     where "root" was given the type:

         # type: dynamic()
         # from: lib/ex_json_schema/schema.ex:125:20
         {root, schema} = resolve_with_root(root, root_schema, scope)

     when defining the variable "root", you must also pattern match on "%ExJsonSchema.Schema.Root{}".

     hint: given pattern matching is enough to catch typing errors, you may optionally convert the struct update into a map update. For example, instead of:

         user = some_function()
         %User{user | name: "John Doe"}

     it is enough to write:

         %User{} = user = some_function()
         %{user | name: "John Doe"}

     typing violation found at:
     │
 127 │     %Root{root | schema: schema}
     │     ~
     │
     └─ lib/ex_json_schema/schema.ex:127:5: ExJsonSchema.Schema.resolve_root/2
```