### PR TITLE
Accept https:// JSON Schema URIs

### DIFF
--- a/lib/ex_json_schema/schema.ex
+++ b/lib/ex_json_schema/schema.ex
@@ -163,6 +163,10 @@ defmodule ExJsonSchema.Schema do
   end
 
   defp schema_module(schema_url, default \\ Draft7)
+
+  defp schema_module("https://json-schema.org/" <> rest, default),
+    do: schema_module("http://json-schema.org/" <> rest, default)
+
   defp schema_module(@draft4_schema_url <> _, _), do: Draft4
   defp schema_module(@draft6_schema_url <> _, _), do: Draft6
   defp schema_module(@draft7_schema_url <> _, _), do: Draft7
@@ -257,6 +261,9 @@ defmodule ExJsonSchema.Schema do
   end
 
   @spec remote_schema(String.t()) :: ExJsonSchema.object()
+  defp remote_schema("https://json-schema.org/" <> rest),
+    do: remote_schema("http://json-schema.org/" <> rest)
+
   defp remote_schema(@current_draft_schema_url <> _), do: Draft7.schema()
   defp remote_schema(@draft4_schema_url <> _), do: Draft4.schema()
   defp remote_schema(@draft6_schema_url <> _), do: Draft6.schema()

--- a/test/ex_json_schema/schema_test.exs
+++ b/test/ex_json_schema/schema_test.exs
@@ -31,6 +31,20 @@ defmodule ExJsonSchema.SchemaTest do
     assert resolve(schema) == %ExJsonSchema.Schema.Root{refs: %{}, schema: schema, version: 7}
   end
 
+  test "accepts both http:// and https:// forms of the JSON Schema URI" do
+    http_schema = %{"$schema" => "http://json-schema.org/draft-07/schema#"}
+    https_schema = %{"$schema" => "https://json-schema.org/draft-07/schema#"}
+
+    assert resolve(http_schema).version == 7
+    assert resolve(https_schema).version == 7
+
+    http_draft6 = %{"$schema" => "http://json-schema.org/draft-06/schema#"}
+    https_draft6 = %{"$schema" => "https://json-schema.org/draft-06/schema#"}
+
+    assert resolve(http_draft6).version == 6
+    assert resolve(https_draft6).version == 6
+  end
+
   test "schema is validated against its meta-schema" do
     schema = %{"properties" => "foo"}
 


### PR DESCRIPTION
Closes #97.

`schema_module/2` and `remote_schema/1` only matched the canonical `http://` prefix, so any schema using `https://json-schema.org/...` (which json-schema.org's own site serves) was rejected with `UnsupportedSchemaVersionError`. Per the spec, `$schema` is an identifier, not a literal URL.

A head clause on each function rewrites `https://json-schema.org/...` to `http://json-schema.org/...` before dispatch. No behavioural change for any other input.

A new test in `test/ex_json_schema/schema_test.exs` exercises both URI forms for drafts 6 and 7. The three failures already present in `schema_test.exs` predate this change (the bundled fixture server returns 500 for those cases on `master`).
